### PR TITLE
chore: remove readme from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
       "transform-object-rest-spread"
     ]
   },
-  "readme": "README.md",
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true


### PR DESCRIPTION
When visiting https://www.gatsbyjs.org/packages/gatsby-plugin-i18n-tags/, you'll see readme.md. Removing it will get the README.md file from your package.